### PR TITLE
Предлагаю повысить версию compileSdkVersion 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 16
+    compileSdkVersion 28
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -42,6 +42,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
+        targetSdkVersion 33
     }
 }
 


### PR DESCRIPTION
Спасибо за плагин!

Отказывается собираться в релизном режиме по соседству с библиотеками, требующими 28 и выше сдк.

Повысил только compileSdkVersion, оставив минимальную версию 16. Не уверен, но, думаю проблем быть не должно на старых мобилках/терминалах